### PR TITLE
feat(kube-rbac-proxy): set non root user in container

### DIFF
--- a/kube-rbac-proxy/v0.5.0/Dockerfile
+++ b/kube-rbac-proxy/v0.5.0/Dockerfile
@@ -23,4 +23,9 @@ ADD https://raw.githubusercontent.com/brancz/kube-rbac-proxy/a6da502b4a4abad511c
     /licenses/LICENSE
 
 ENTRYPOINT ["./kube-rbac-proxy"]
+ENV USER_ID 1000
+ENV USER_NAME kube-rbac-proxy-user
+RUN adduser --uid $USER_ID $USER_NAME
+USER $USER_ID
+
 EXPOSE 8080


### PR DESCRIPTION
When user is not set following error appears when kube-rbac-proxy is used in bundle for Helm operator:
```
Events:
  Type     Reason          Age                  From               Message
  ----     ------          ----                 ----               -------
  Normal   Scheduled       2m17s                default-scheduler  Successfully assigned openshift-operators/sumologic-helm-operator-596c46d55d-cqntn to ip-10-0-146-11.us-west-1.compute.internal
  Normal   AddedInterface  2m15s                multus             Add eth0 [10.131.2.10/23]
  Normal   Pulling         2m14s                kubelet            Pulling image "public.ecr.aws/sumologic/kube-rbac-proxy:v0.5.0-ubi"
  Normal   Pulled          2m3s                 kubelet            Successfully pulled image "public.ecr.aws/sumologic/kube-rbac-proxy:v0.5.0-ubi" in 11.030085111s
  Normal   Pulling         2m3s                 kubelet            Pulling image "public.ecr.aws/sumologic/sumologic-kubernetes-collection-helm-operator:2.1.4-0-rc.0"
  Normal   Pulled          111s                 kubelet            Successfully pulled image "public.ecr.aws/sumologic/sumologic-kubernetes-collection-helm-operator:2.1.4-0-rc.0" in 12.277107926s
  Normal   Created         111s                 kubelet            Created container operator
  Normal   Started         111s                 kubelet            Started container operator
  Warning  Failed          12s (x10 over 2m3s)  kubelet            Error: container has runAsNonRoot and image will run as root
  Normal   Pulled          12s (x9 over 110s)   kubelet            Container image "public.ecr.aws/sumologic/kube-rbac-proxy:v0.5.0-ubi" already present on machine
```

with new image the issue does not exist:

```
  Events:
  Type    Reason          Age   From               Message
  ----    ------          ----  ----               -------
  Normal  Scheduled       28s   default-scheduler  Successfully assigned openshift-operators/sumologic-helm-operator-5f499f6dbf-rlmnw to ip-10-0-146-11.us-west-1.compute.internal
  Normal  AddedInterface  26s   multus             Add eth0 [10.131.2.24/23]
  Normal  Pulling         26s   kubelet            Pulling image "ghcr.io/kkujawa-sumo/kube-rbac-proxy:new"
  Normal  Pulled          23s   kubelet            Successfully pulled image "ghcr.io/kkujawa-sumo/kube-rbac-proxy:new" in 3.031579755s
  Normal  Created         23s   kubelet            Created container kube-rbac-proxy
  Normal  Started         23s   kubelet            Started container kube-rbac-proxy
  Normal  Pulling         23s   kubelet            Pulling image "ghcr.io/kkujawa-sumo/sumologic-kubernetes-collection-helm-operator:v2.1.4-0-rc.0-1-geaffe5f"
  Normal  Pulled          14s   kubelet            Successfully pulled image "ghcr.io/kkujawa-sumo/sumologic-kubernetes-collection-helm-operator:v2.1.4-0-rc.0-1-geaffe5f" in 9.156220205s
  Normal  Created         13s   kubelet            Created container operator
  Normal  Started         13s   kubelet            Started container operator
```
  
 