### PR TITLE
Change references to versions from tags

### DIFF
--- a/kube-rbac-proxy/v0.8.0/Dockerfile
+++ b/kube-rbac-proxy/v0.8.0/Dockerfile
@@ -1,5 +1,5 @@
 ## Use original image to copy files from
-## ref: https://github.com/brancz/kube-rbac-proxy/blob/2924b3a197171acc78dfc275c828484d00061d43/Dockerfile
+## ref: https://github.com/brancz/kube-rbac-proxy/blob/v0.8.0/Dockerfile
 FROM gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0 as builder
 
 ## Build RedHat compliant image
@@ -19,7 +19,7 @@ RUN yum update -y \
 COPY --from=builder \
     /usr/local/bin/kube-rbac-proxy \
     /usr/local/bin/kube-rbac-proxy
-ADD https://raw.githubusercontent.com/brancz/kube-rbac-proxy/a6da502b4a4abad511cb1afa87b0b52c74a89987/LICENSE \
+ADD https://raw.githubusercontent.com/brancz/kube-rbac-proxy/v0.8.0/LICENSE \
     /licenses/LICENSE
 
 ENTRYPOINT ["/usr/local/bin/kube-rbac-proxy"]

--- a/kube-state-metrics/v1.9.8/Dockerfile
+++ b/kube-state-metrics/v1.9.8/Dockerfile
@@ -1,5 +1,5 @@
 ## Use original image to copy files from
-## ref: https://github.com/kubernetes/kube-state-metrics/blob/e72315512a38653b19dcfe4429f93eadedc0ea96/Dockerfile
+## ref: https://github.com/kubernetes/kube-state-metrics/blob/v1.9.8/Dockerfile
 FROM quay.io/coreos/kube-state-metrics:v1.9.8 as builder
 
 ## Build RedHat compliant image
@@ -16,7 +16,7 @@ LABEL name="Kube-state-metrics" \
 COPY --from=builder \
     /kube-state-metrics \
     /
-ADD https://raw.githubusercontent.com/kubernetes/kube-state-metrics/b3fa5852d755c912c2601c53781a58567c822b81/LICENSE \
+ADD https://raw.githubusercontent.com/kubernetes/kube-state-metrics/v1.9.8/LICENSE \
     /licenses/LICENSE
 
 USER nobody

--- a/node-exporter/v1.3.1/Dockerfile
+++ b/node-exporter/v1.3.1/Dockerfile
@@ -1,5 +1,5 @@
 ## Use original image to copy files from
-## ref: https://github.com/prometheus/node_exporter/blob/a2321e7b940ddcff26873612bccdf7cd4c42b6b6/Dockerfile
+## ref: https://github.com/prometheus/node_exporter/blob/v1.3.1/Dockerfile
 FROM quay.io/prometheus/node-exporter:v1.3.1 as builder
 
 ## Build RedHat compliant image
@@ -16,7 +16,7 @@ LABEL name="Node-exporter" \
 COPY --from=builder \
     /bin/node_exporter \
     /bin/node_exporter
-ADD https://raw.githubusercontent.com/prometheus/node_exporter/3715be6ae899f2a9b9dbfd9c39f3e09a7bd4559f/LICENSE \
+ADD https://raw.githubusercontent.com/prometheus/node_exporter/v1.3.1/LICENSE \
     /licenses/LICENSE
 
 EXPOSE      9100

--- a/prometheus-operator/v0.44.0/Dockerfile
+++ b/prometheus-operator/v0.44.0/Dockerfile
@@ -1,5 +1,5 @@
 ## Use original image to copy files from
-## ref: https://github.com/prometheus-operator/prometheus-operator/blob/d8b7d3766225908d0239fd0d78258892cd0fc384/Dockerfile
+## ref: https://github.com/prometheus-operator/prometheus-operator/blob/v0.44.0/Dockerfile
 FROM quay.io/prometheus-operator/prometheus-operator:v0.44.0 as builder
 
 ## Build RedHat compliant image
@@ -16,7 +16,7 @@ LABEL name="Prometheus-operator" \
 COPY --from=builder \
     /bin/operator \
     /bin/operator
-ADD https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/b86ab77239f2a11ee69ad05b24122958d8b2df5b/LICENSE \
+ADD https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.44.0/LICENSE \
     /licenses/LICENSE
 
 # On busybox 'nobody' has uid `65534'


### PR DESCRIPTION
Using references from tags improve readability and make clear which version is in use.

It is not always possible to use versions from tags because repositories with original Dockerfiles are sometimes managed without tags but when it is possible references should be set to version from tags.