### PR TITLE
set non-root users in Dockerfiles

### DIFF
--- a/fluent-bit/v1.6.10/Dockerfile
+++ b/fluent-bit/v1.6.10/Dockerfile
@@ -62,4 +62,5 @@ COPY --from=builder /fluent-bit /fluent-bit
 COPY --from=builder /tmp/src/LICENSE /licenses/
 
 EXPOSE 2020
+USER nobody
 CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]

--- a/telegraf-operator/v1.3.5/Dockerfile
+++ b/telegraf-operator/v1.3.5/Dockerfile
@@ -19,4 +19,5 @@ COPY --from=builder /manager .
 ADD https://raw.githubusercontent.com/influxdata/telegraf-operator/v1.3.5/LICENSE \
     /licenses/LICENSE
 
+USER nobody
 ENTRYPOINT ["/manager"]

--- a/telegraf/1.21.2/Dockerfile
+++ b/telegraf/1.21.2/Dockerfile
@@ -27,5 +27,6 @@ ADD https://raw.githubusercontent.com/influxdata/influxdata-docker/dd108978ea0e5
 EXPOSE 8125/udp 8092/udp 8094
 
 COPY --from=builder /entrypoint.sh /entrypoint.sh
+USER nobody
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["telegraf"]


### PR DESCRIPTION
    fix(fluent-bit): set non-root user in Dockerfile
    fix(telegraf): set non-root user in Dockerfile
    fix(telegraf-operator): set non-root user in Dockerfile


It is needed to fix problem reported by [openshift-preflight](https://github.com/redhat-openshift-ecosystem/openshift-preflight) for these images:

```
        "failed": [
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 0,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication",
                "help": "Check RunAsNonRoot encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Indicate a specific USER in the dockerfile or containerfile",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.45/html/red_hat_openshift_software_certification_policy_guide/assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.45/html/red_hat_openshift_software_certification_policy_guide/assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            }
        ],
```
