### PR TITLE
fix(prometheus): add ENVs with description and summary to fix information in catalog.redhat.com

### DIFF
--- a/prometheus/v2.22.1/Dockerfile
+++ b/prometheus/v2.22.1/Dockerfile
@@ -7,12 +7,15 @@ ARG ARCH="amd64"
 ARG OS="linux"
 FROM registry.access.redhat.com/ubi8/ubi:8.6
 
+ENV SUMMARY="UBI based prometheus" \
+    DESCRIPTION="Prometheus, a Cloud Native Computing Foundation project, is a systems and service monitoring system."
+
 LABEL name="Prometheus" \
       vendor="Sumo Logic" \
       version="2.22.1" \
       release="2" \
-      summary="UBI based prometheus" \
-      description="Prometheus, a Cloud Native Computing Foundation project, is a systems and service monitoring system." \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
       maintainer="collection@sumologic.com"
 
 ARG ARCH="amd64"


### PR DESCRIPTION
<img width="1439" alt="Screenshot 2022-08-18 at 09 37 03" src="https://user-images.githubusercontent.com/73836361/185337450-a891e431-242c-413f-8481-29cd8bf30c85.png">

Information in "Technical Information" tab is taken from ENVs.
