### PR TITLE
fix(prometheus): add io.k8s.description label to Dockerfile

### DIFF
--- a/prometheus/v2.22.1/Dockerfile
+++ b/prometheus/v2.22.1/Dockerfile
@@ -16,6 +16,7 @@ LABEL name="Prometheus" \
       release="2" \
       summary="$SUMMARY" \
       description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
       maintainer="collection@sumologic.com"
 
 ARG ARCH="amd64"


### PR DESCRIPTION
this is needed to fix information in catalog.redhat.com