### PR TITLE
feat: add `telegraf-operator-ubi:v1.3.10`

### DIFF
--- a/telegraf-operator/v1.3.10/Dockerfile
+++ b/telegraf-operator/v1.3.10/Dockerfile
@@ -1,0 +1,27 @@
+## Use original image to copy files from
+## ref: https://github.com/influxdata/telegraf-operator/blob/v1.3.10/Dockerfile
+FROM quay.io/influxdb/telegraf-operator:v1.3.10 as builder
+
+## Build RedHat compliant image
+FROM registry.access.redhat.com/ubi8-minimal:8.8
+
+ENV SUMMARY="UBI based telegraf-operator" \
+    DESCRIPTION="The telegraf facilitates management of telegraf CRDs in Kubernetes."
+
+LABEL name="telegraf-operator" \
+      vendor="Sumo Logic" \
+      version="1.3.10" \
+      release="1" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      maintainer="collection@sumologic.com"
+
+WORKDIR /
+COPY --from=builder /manager .
+
+ADD https://raw.githubusercontent.com/influxdata/telegraf-operator/v1.3.10/LICENSE \
+    /licenses/LICENSE
+
+USER nobody
+ENTRYPOINT ["/manager"]

--- a/telegraf-operator/v1.3.10/Makefile
+++ b/telegraf-operator/v1.3.10/Makefile
@@ -1,0 +1,2 @@
+build:
+	docker build . -t telegraf-operator-ubi:v1.3.10


### PR DESCRIPTION
Compared to `v1.3.5`:

- Bumps UBI base image from `v8.6` to latest `v8.8`
- Updates Telegraf Operator version from `v1.3.5` to `v1.3.10`