### PR TITLE
feat: add opentelemetry operator v0.63.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,3 +95,6 @@ build-kubernetes-fluentd-1.14.6-sumo-5:
 
 build-opentelemetry-operator-0.51.0:
 	${MAKE} -C opentelemetry-operator/0.51.0
+
+build-opentelemetry-operator-0.63.1:
+	${MAKE} -C opentelemetry-operator/0.63.1

--- a/opentelemetry-operator/0.63.1/Dockerfile
+++ b/opentelemetry-operator/0.63.1/Dockerfile
@@ -1,0 +1,30 @@
+## Use original image to copy files from
+## ref: https://github.com/open-telemetry/opentelemetry-operator/blob/v0.63.1/Dockerfile
+
+FROM ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.63.1 as builder
+
+
+## Build RedHat compliant image
+FROM registry.access.redhat.com/ubi8/ubi:8.8
+
+WORKDIR /
+COPY --from=builder  /manager .
+
+ENV SUMMARY="UBI based opentelemetry operator" \
+    DESCRIPTION="OpenTelemetry Operator manages OpenTelemetry Collector and auto-instrumentation of the workloads using OpenTelemetry instrumentation libraries"
+
+LABEL name="opentelemetry-operator" \
+      vendor="Sumo Logic" \
+      version="0.63.1" \
+      release="1" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      maintainer="collection@sumologic.com"
+
+ADD https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/v0.63.1/LICENSE \
+    /licenses/LICENSE
+
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]

--- a/opentelemetry-operator/0.63.1/Makefile
+++ b/opentelemetry-operator/0.63.1/Makefile
@@ -1,0 +1,2 @@
+build:
+	docker build . -t opentelemetry-collector:0.63.1


### PR DESCRIPTION
Compared to 0.51.0:

Bumps UBI base image from v8.6 to latest v8.8
Updates Opentelemtry Operator version from 0.51.0 to 0.63.1

published as `public.ecr.aws/sumologic/opentelemetry-operator:0.63.1-ubi` https://gallery.ecr.aws/sumologic/opentelemetry-operator