### PR TITLE
feat(scripts/list-images/py): fix the script and fetch instrumentation images

### DIFF
--- a/scripts/list-images.py
+++ b/scripts/list-images.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import argparse
 import re
+import urllib.error
 import urllib.request
 
 def parse_args():
@@ -25,7 +26,10 @@ def get_sumo_images(version, values):
     for match in matches:
         # Detect Fluent Bit image used by Tailing Sidecar
         if re.match('.*tailing-sidecar:.*', match):
-            content = urllib.request.urlopen(f"https://raw.githubusercontent.com/SumoLogic/tailing-sidecar/v{match.split(':')[-1]}/sidecar/Dockerfile").read()
+            try:
+                content = urllib.request.urlopen(f"https://raw.githubusercontent.com/SumoLogic/tailing-sidecar/v{match.split(':')[-1]}/sidecar/fluentbit/Dockerfile").read()
+            except urllib.error.HTTPError:
+                content = urllib.request.urlopen(f"https://raw.githubusercontent.com/SumoLogic/tailing-sidecar/v{match.split(':')[-1]}/sidecar/Dockerfile").read()
             fluent_bit_matches = re.findall('FROM (fluent/fluent-bit:.*?)\\\\n', str(content))
             if fluent_bit_matches == None:
                 sys.exit(-1)

--- a/scripts/values.yaml
+++ b/scripts/values.yaml
@@ -15,3 +15,5 @@ tailing-sidecar-operator:
   enabled: true
 opentelemetry-operator:
   enabled: true
+  createDefaultInstrumentation: true
+  instrumentationNamespaces: "sumologic"


### PR DESCRIPTION
* Fix after moving tailing sidecar to separate directory
* fetch instrumentation images
* control fetching base images (fluent-bit for tailing sidecar)

```
docker.io/bitnami/metrics-server:0.7.0-debian-12-r7
ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:0.7.0
ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.26.0
ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.40.0
ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:0.39b0
ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.93.0
public.ecr.aws/docker/library/busybox:1.36.0
public.ecr.aws/falcosecurity/falco-driver-loader:0.36.2
public.ecr.aws/falcosecurity/falco-no-driver:0.36.2
public.ecr.aws/sumologic/kubernetes-setup:3.12.1
public.ecr.aws/sumologic/kubernetes-tools-kubectl:2.22.0
public.ecr.aws/sumologic/sumologic-otel-collector:0.92.0-sumo-0
public.ecr.aws/sumologic/tailing-sidecar-operator:0.11.0
public.ecr.aws/sumologic/tailing-sidecar:0.11.0
public.ecr.aws/sumologic/telegraf:1.21.2
quay.io/brancz/kube-rbac-proxy:v0.11.0
quay.io/brancz/kube-rbac-proxy:v0.15.0
quay.io/influxdb/telegraf-operator:v1.3.11
quay.io/prometheus/node-exporter:v1.3.1
registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.7.0
```