### PR TITLE
feat(scripts/list-images): fetch prometheus setup related images

### DIFF
--- a/scripts/values.yaml
+++ b/scripts/values.yaml
@@ -1,6 +1,9 @@
 sumologic:
   accessId: dummy
   accessKey: dummy
+  metrics:
+    remoteWriteProxy:
+      enabled: true
 metrics-server:
   enabled: true
   apiService:
@@ -17,3 +20,8 @@ opentelemetry-operator:
   enabled: true
   createDefaultInstrumentation: true
   instrumentationNamespaces: "sumologic"
+kube-prometheus-stack:
+  prometheusOperator:
+    enabled: true
+  prometheus:
+    enabled: false


### PR DESCRIPTION
```
busybox:latest
docker.io/bitnami/metrics-server:0.7.0-debian-12-r7
ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:0.7.0
ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.26.0
ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:0.40.0
ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:0.39b0
ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.93.0
public.ecr.aws/docker/library/busybox:1.36.0
public.ecr.aws/falcosecurity/falco-driver-loader:0.36.2
public.ecr.aws/falcosecurity/falco-no-driver:0.36.2
public.ecr.aws/sumologic/kubernetes-setup:3.12.1
public.ecr.aws/sumologic/kubernetes-tools-kubectl:2.22.0
public.ecr.aws/sumologic/nginx-unprivileged:1.25.2-alpine-sumo-1
public.ecr.aws/sumologic/sumologic-otel-collector:0.92.0-sumo-0
public.ecr.aws/sumologic/tailing-sidecar-operator:0.11.0
public.ecr.aws/sumologic/tailing-sidecar:0.11.0
public.ecr.aws/sumologic/telegraf:1.21.2
quay.io/brancz/kube-rbac-proxy:v0.11.0
quay.io/brancz/kube-rbac-proxy:v0.15.0
quay.io/influxdb/telegraf-operator:v1.3.11
quay.io/prometheus-operator/prometheus-config-reloader:v0.59.2
quay.io/prometheus-operator/prometheus-operator:v0.59.2
quay.io/prometheus/node-exporter:v1.3.1
quay.io/thanos/thanos:v0.28.0
registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.7.0
```