### PR TITLE
feat: add script to submit image to Red Hat registry and certify

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,13 @@
+# Scripts
+
+Description of scripts in this directory:
+
+- [list-images.py](./list-images.py) - script which is used to list all images used in the Sumo Logic Kubernetes Collection Helm Chart
+- [build-push-all.sh](./build-push-all.sh) - script which is used to build and push [UBI](https://catalog.redhat.com/software/base-images) based container images and push them to Red Hat container registry
+- [submit_image.sh](./submit_image.sh) - script which is used to submit image to Red Hat container registry and certify the image.
+  environment variables:
+
+  - `CONTAINER_PROJECT_ID` - container project ID from [connect.redhat.com/](https://connect.redhat.com/)
+  - `CONTAINER_REGISTRY_KEY` - container registry key from [connect.redhat.com/](https://connect.redhat.com/)
+  - `PYAXIS_API_TOKEN` -  pyxis API key from  [connect.redhat.com/](https://connect.redhat.com/), please see [api-keys](https://connect.redhat.com/account/api-keys)
+  - `SUMOLOGIC_IMAGE` - UBI based image name e.g. `public.ecr.aws/sumologic/metrics-server:0.7.0-debian-12-r8-ubi`

--- a/scripts/submit_image.sh
+++ b/scripts/submit_image.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z ${CONTAINER_PROJECT_ID} ] || [ -z ${CONTAINER_REGISTRY_KEY} ] || [ -z ${SUMOLOGIC_IMAGE} ] || [ -z ${PYAXIS_API_TOKEN} ] 
+then
+    echo "One of required environment variables is missing"
+    echo "required environment variables: CONTAINER_PROJECT_ID, CONTAINER_REGISTRY_KEY, SUMOLOGIC_IMAGE, PYAXIS_API_TOKEN"
+    exit 1
+fi
+
+echo "${CONTAINER_REGISTRY_KEY}" | docker login -u "redhat-isv-containers+${CONTAINER_PROJECT_ID}-robot" quay.io --password-stdin
+
+# extract tag
+TAG="${SUMOLOGIC_IMAGE##*:}" # treat everything after `:` as version
+
+# push image
+docker tag ${SUMOLOGIC_IMAGE} "quay.io/redhat-isv-containers/${CONTAINER_PROJECT_ID}:${TAG}"
+docker push "quay.io/redhat-isv-containers/${CONTAINER_PROJECT_ID}:${TAG}"
+
+# prepare temporary auth file
+AUTH_KEY=$(echo -n  "redhat-isv-containers+${CONTAINER_PROJECT_ID}-robot:${CONTAINER_REGISTRY_KEY}" | base64 --wrap 0)
+AUTH_CONTENT="{\"auths\": {\"quay.io\": {\"auth\": \"${AUTH_KEY}\"}}}"
+echo ${AUTH_CONTENT} > temp_auth.json
+
+# submit image
+preflight check container "quay.io/redhat-isv-containers/${CONTAINER_PROJECT_ID}:${TAG}" \
+--submit \
+--pyxis-api-token="${PYAXIS_API_TOKEN}" \
+--certification-project-id="${CONTAINER_PROJECT_ID}" \
+--docker-config=temp_auth.json
+
+# add latest tag
+docker tag  ${SUMOLOGIC_IMAGE} "quay.io/redhat-isv-containers/${CONTAINER_PROJECT_ID}:latest"
+docker push "quay.io/redhat-isv-containers/${CONTAINER_PROJECT_ID}:latest"
+
+rm temp_auth.json


### PR DESCRIPTION
feat: add script to submit image to Red Hat registry and certify

note:
`CONTAINER_PROJECT_ID`, `CONTAINER_REGISTRY_KEY` and `PYAXIS_API_TOKEN` needs to be taken from Red Hat platform (https://connect.redhat.com/)

`SUMOLOGIC_IMAGE` - it is the UBI based sumologic image name e.g. `public.ecr.aws/sumologic/metrics-server:0.7.0-debian-12-r8-ubi`
 