### PR TITLE
feat: remove check, push and certify in favor of action parameter

### DIFF
--- a/.github/workflows/run_manually.yml
+++ b/.github/workflows/run_manually.yml
@@ -3,7 +3,7 @@ name: Manual test run
 on:
   workflow_dispatch:
     inputs:
-      push:
+      action:
         type: choice
         description: Action to perform
         options:

--- a/.github/workflows/run_manually.yml
+++ b/.github/workflows/run_manually.yml
@@ -5,22 +5,12 @@ on:
     inputs:
       push:
         type: choice
-        description: Push the image to repository
+        description: Action to perform
         options:
-          - "true"
-          - "false"
-      check:
-        type: choice
-        description: Check the image using preflight
-        options:
-          - "true"
-          - "false"
-      certify:
-        type: choice
-        description: Certify the image
-        options:
-          - "true"
-          - "false"
+          - "build"
+          - "push"
+          - "check"
+          - "certify"
       force:
         type: choice
         description: Perform action even if image already exists
@@ -44,9 +34,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     env:
-      PUSH: "${{ inputs.push }}"
-      CHECK: "${{ inputs.check }}"
-      CERTIFY: "${{ inputs.certify }}"
+      ACTION: "${{ inputs.action }}"
       FORCE: "${{ inputs.force }}"
       NAME: "${{ inputs.NAME }}"
       VERSION: "${{ inputs.VERSION }}"
@@ -66,10 +54,8 @@ jobs:
       - name: Build push
         run: |
           PYAXIS_API_TOKEN="${PYAXIS_API_TOKEN=}" \
+          ACTION="${ACTION}"
           NAME="${NAME}" \
           VERSION="${VERSION}" \
-          CHECK="${CHECK}" \
-          PUSH="${PUSH}" \
           FORCE="${FORCE}" \
-          CERTIFY="${CERTIFY}" \
           ./scripts/build-push.sh

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ list-images-v3:
     	--version v3
 
 build-all:
-	CHECK=false ./scripts/build-push-all.sh
+	ACTION=build ./scripts/build-push-all.sh
 
 check:
-	PUSH=true CHECK=true CERTIFY=false ./scripts/build-push-all.sh
+	ACTION=check ./scripts/build-push-all.sh
 
 certify:
-	PUSH=true CHECK=true CERTIFY=true ./scripts/build-push-all.sh
+	ACTION=certify ./scripts/build-push-all.sh
 
 _login:
 	aws ecr-public get-login-password --region us-east-1 \

--- a/scripts/build-push-all.sh
+++ b/scripts/build-push-all.sh
@@ -32,9 +32,7 @@ for IMAGE in ${IMAGES}; do
     NAME="${IMAGE%%:*}"
     NAME="${NAME##*/}"
 
-   PYAXIS_API_TOKEN="${PYAXIS_API_TOKEN=}" \
    NAME="${NAME}" \
-   ACTION="${ACTION}" \
    VERSION="${VERSION}" \
    ./scripts/build-push.sh
 done

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -11,9 +11,11 @@ function usage() {
 PYAXIS_API_TOKEN    token for Red Hat API
 NAME                image to build, for example 'opentelemetry-operator'
 VERSION             version to build from (without prefix), for example 'v0.95.0'
-PUSH                set to 'true' to push image. Default is 'false'
-CHECK               set to 'true' to perform preflight check on the image. Default is 'false', requires 'PUSH=true'
-CERTIFY             set to 'true' to certify image. If 'false', it will use '-dev' suffix for image tag. Default is 'false', requires 'CHECK=true'
+ACTION              action to perform. Default is 'build', can be 'build', 'push', 'check' or 'certify'
+                    - 'build' - build image with '-dev' suffix
+                    - 'push' - build and push image with '-dev' suffix 
+                    - 'check' - build and push image with '-dev' suffix and then perform preflight check
+                    - 'certify' - build and push image without any suffix, perform preflight check and perform certification process
 FORCE               set to 'true' to perform action if image already exist in repository. Default is 'false'
 PLATFORM            platform to test. Default is 'amd64'"
 }
@@ -51,11 +53,21 @@ readonly CERTIFY="${CERTIFY:-false}"
 readonly FORCE="${FORCE:-false}"
 readonly PYAXIS_API_TOKEN="${PYAXIS_API_TOKEN}"
 readonly PLATFORM="${PLATFORM:-amd64}"
+readonly ACTION_BUILD="build"
+readonly ACTION_PUSH="push"
+readonly ACTION_CHECK="check"
+readonly ACTION_CERTIFY="certify"
+readonly ACTION="${ACTION:-${ACTION_BUILD}}"
 DEV_SUFFIX=""
 
 ## Sumo Logic Helm Operator project id
 ## rel: https://connect.redhat.com/manage/products/6075d88c2b962feb86bea730/overview
 readonly OPERATOR_PROJECT_ID=6075d88c2b962feb86bea730
+
+if ! [[ "$ACTION" =~ ${ACTION_BUILD}|${ACTION_PUSH}|${ACTION_CHECK}|${ACTION_CERTIFY} ]]; then
+    echo "ACTION should be '${ACTION_BUILD}', '${ACTION_PUSH}', '${ACTION_CHECK}' or ${ACTION_CERTIFY}"
+    exit 1
+fi
 
 if [[ -z "${NAME}" ]]; then
     echo 'Missing NAME variable' 2>&1
@@ -69,19 +81,21 @@ if [[ -z "${VERSION}" ]]; then
     exit 1
 fi
 
-if [[ -z "${PYAXIS_API_TOKEN}" ]]; then
+if [[ -z "${PYAXIS_API_TOKEN}" && "${ACTION}" =~ ${ACTION_PUSH}|${ACTION_CHECK}|${ACTION_CERTIFY} ]]; then
     echo 'Missing PYAXIS_API_TOKEN variable' 2>&1
     usage
     exit 1
 fi
 
-if [[ "${CERTIFY}" == "false" ]]; then
+if [[ "${ACTION}" != "${ACTION_CERTIFY}" ]]; then
     DEV_SUFFIX="-dev"
 fi
 readonly DEV_SUFFIX
 
 readonly UBI_VERSION="${VERSION}-ubi"
 readonly IMAGE_NAME="${SUMO_REGISTRY}${NAME}:${UBI_VERSION}${DEV_SUFFIX}"
+
+echo "Image: ${IMAGE_NAME}"
 
 if docker pull "${IMAGE_NAME}" && [[ "${FORCE}" == "false" ]]; then
     echo "Image ${IMAGE_NAME} exists, there is no need to push it once again, continue with next image." 2>&1
@@ -94,20 +108,19 @@ fi
 make -C "${NAME}" build IMAGE_NAME="${IMAGE_NAME}" UPSTREAM_VERSION="${UPSTREAM_VERSION}"
 
 # Push image
-if [[ "${PUSH}" != "true" ]]; then
+if ! [[ "${ACTION}" =~ ${ACTION_PUSH}|${ACTION_CHECK}|${ACTION_CERTIFY} ]]; then
     exit 0
 fi
 
 echo "Pushing image, image: ${IMAGE_NAME}" 2>&1
 make -C "${NAME}" push IMAGE_NAME="${IMAGE_NAME}" UPSTREAM_VERSION="${UPSTREAM_VERSION}"
 
-if [[ "${CHECK}" == "false" ]]; then
+if ! [[ "${ACTION}" =~ ${ACTION_CHECK}|${ACTION_CERTIFY} ]]; then
     exit 0
 fi
 check
 
-if [[ "${CERTIFY}" == "false" ]]; then
+if ! [[ "${ACTION}" =~ ${ACTION_CERTIFY} ]]; then
     exit 0
 fi
-
 submit

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -98,7 +98,7 @@ readonly IMAGE_NAME="${SUMO_REGISTRY}${NAME}:${UBI_VERSION}${DEV_SUFFIX}"
 echo "Image: ${IMAGE_NAME}"
 
 if docker pull "${IMAGE_NAME}" && [[ "${FORCE}" == "false" ]]; then
-    echo "Image ${IMAGE_NAME} exists, there is no need to push it once again, continue with next image." 2>&1
+    echo "Image ${IMAGE_NAME} exists, there is no need to push it once again." 2>&1
     exit 0
 fi
 

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -81,7 +81,7 @@ if [[ -z "${VERSION}" ]]; then
     exit 1
 fi
 
-if [[ -z "${PYAXIS_API_TOKEN}" && "${ACTION}" =~ ${ACTION_PUSH}|${ACTION_CHECK}|${ACTION_CERTIFY} ]]; then
+if [[ -z "${PYAXIS_API_TOKEN}" && "${ACTION}" =~ ${ACTION_CHECK}|${ACTION_CERTIFY} ]]; then
     echo 'Missing PYAXIS_API_TOKEN variable' 2>&1
     usage
     exit 1


### PR DESCRIPTION
Rely on action parameter:

```
ACTION              action to perform. Default is 'build', can be 'build', 'push', 'check' or 'certify'
                    - 'build' - build image with '-dev' suffix
                    - 'push' - build and push image with '-dev' suffix 
                    - 'check' - build and push image with '-dev' suffix and then perform preflight check
                    - 'certify' - build and push image without any suffix, perform preflight check and perform certification process
```