### PR TITLE
fix: fic obtaining project by image name

### DIFF
--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -33,7 +33,7 @@ function check(){
 function submit(){
     echo "Submitting image for certification, image: ${IMAGE_NAME}"
     ## Fetch container project id based on directory(image) name
-    CONTAINER_PROJECT_ID="$(curl -sH "X-API-KEY: ${PYAXIS_API_TOKEN}" "https://catalog.redhat.com/api/containers/v1/product-listings/id/${OPERATOR_PROJECT_ID}/projects/certification" | jq ".data[] | select(.name == \"${NAME}\")._id" --raw-output)"
+    CONTAINER_PROJECT_ID="$(curl -sH "X-API-KEY: ${PYAXIS_API_TOKEN}" "https://catalog.redhat.com/api/containers/v1/product-listings/id/${OPERATOR_PROJECT_ID}/projects/certification" | jq ".data[] | select(.container.repository_name == \"${NAME}\")._id" --raw-output)"
 
     if [[ -z ${CONTAINER_PROJECT_ID} ]]; then
         echo "Missing project for ${IMAGE_NAME}"


### PR DESCRIPTION
I changed the way how the projects are being created and repository_name should be used to get the project from API

https://github.com/SumoLogic/sumologic-openshift-images/blob/4a4f768be0354c10fdbcfa3f10909d578e300cd9/scripts/new_project.json#L19

https://github.com/SumoLogic/sumologic-openshift-images/blob/4a4f768be0354c10fdbcfa3f10909d578e300cd9/scripts/build-push.sh#L75-L76