### PR TITLE
fix: remove unnecessary colon from image with digest

### DIFF
--- a/scripts/get_images_sha256.sh
+++ b/scripts/get_images_sha256.sh
@@ -25,7 +25,7 @@ for IMAGE in ${IMAGES}; do
   else
     # Treat everything after `:` as digest
     DIGEST="${DIGEST##*:}"
-    REDHAT_IMAGE_WITH_SHA256=${REDHAT_REGISTRY}${NAME}:@sha256:${DIGEST}
+    REDHAT_IMAGE_WITH_SHA256=${REDHAT_REGISTRY}${NAME}@sha256:${DIGEST}
   fi
 
   echo ${REDHAT_IMAGE}


### PR DESCRIPTION
example image format with fix `registry.connect.redhat.com/sumologic/kubernetes-setup@sha256:157290d458724d63dde2d8b2b81b8184618ae07de6776f56ab33f3e3cb0566b5`