### PR TITLE
Update ubi images in dockerfile 

### DIFF
--- a/autoinstrumentation-dotnet/Dockerfile
+++ b/autoinstrumentation-dotnet/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/autoinstrumentation-dotnet:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/autoinstrumentation-java/Dockerfile
+++ b/autoinstrumentation-java/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/autoinstrumentation-java:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/autoinstrumentation-nodejs/Dockerfile
+++ b/autoinstrumentation-nodejs/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/autoinstrumentation-nodejs:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/autoinstrumentation-python/Dockerfile
+++ b/autoinstrumentation-python/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/autoinstrumentation-python:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/busybox/Dockerfile
+++ b/busybox/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 
 LABEL name="Busybox Base image" \
     vendor="Sumo Logic" \

--- a/fluent-bit/Dockerfile
+++ b/fluent-bit/Dockerfile
@@ -1,6 +1,6 @@
 ARG UPSTREAM_VERSION
 
-FROM registry.access.redhat.com/ubi9/ubi:9.6 as builder
+FROM registry.access.redhat.com/ubi9/ubi:9.7 as builder
 ARG UPSTREAM_VERSION
 
 ARG BISON_VERSION=3.8.2

--- a/kube-rbac-proxy/Dockerfile
+++ b/kube-rbac-proxy/Dockerfile
@@ -4,7 +4,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/kube-rbac-proxy:v${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/kube-state-metrics/Dockerfile
+++ b/kube-state-metrics/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/kube-state-metrics:v${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/metrics-server/Dockerfile
+++ b/metrics-server/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM docker.io/bitnamilegacy/metrics-server:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/node-exporter/Dockerfile
+++ b/node-exporter/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/node-exporter:v${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/opentelemetry-collector/Dockerfile
+++ b/opentelemetry-collector/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM otel/opentelemetry-collector-contrib:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/opentelemetry-operator/Dockerfile
+++ b/opentelemetry-operator/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/opentelemetry-operator:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/prometheus-config-reloader/Dockerfile
+++ b/prometheus-config-reloader/Dockerfile
@@ -4,7 +4,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/prometheus-config-reloader:v${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/prometheus-operator/Dockerfile
+++ b/prometheus-operator/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/prometheus-operator:v${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -6,7 +6,7 @@ FROM public.ecr.aws/sumologic/prometheus:v${UPSTREAM_VERSION} as builder
 ## Build RedHat compliant image
 ARG ARCH="amd64"
 ARG OS="linux"
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/scripts/list-images.py
+++ b/scripts/list-images.py
@@ -26,16 +26,24 @@ def get_sumo_images(version, values, fetch_base):
     
     for match in matches:
         if fetch_base:
-            # Detect Fluent Bit image used by Tailing Sidecar
+            # Detect Fluent Bit image used by Tailing Sidecar (older versions)
             if re.match('.*tailing-sidecar:.*', match):
-                try:
-                    content = urllib.request.urlopen(f"https://raw.githubusercontent.com/SumoLogic/tailing-sidecar/v{match.split(':')[-1]}/sidecar/fluentbit/Dockerfile").read()
-                except urllib.error.HTTPError:
-                    content = urllib.request.urlopen(f"https://raw.githubusercontent.com/SumoLogic/tailing-sidecar/v{match.split(':')[-1]}/sidecar/Dockerfile").read()
-                fluent_bit_matches = re.findall('FROM (fluent/fluent-bit:.*?)\\\\n', str(content))
-                if fluent_bit_matches == None:
-                    sys.exit(-1)
-                matches.extend(fluent_bit_matches)
+                version_tag = match.split(':')[-1]
+                candidate_paths = [
+                    f"sidecar/fluentbit/Dockerfile",
+                    f"sidecar/Dockerfile",
+                ]
+                content = None
+                for path in candidate_paths:
+                    try:
+                        content = urllib.request.urlopen(f"https://raw.githubusercontent.com/SumoLogic/tailing-sidecar/v{version_tag}/{path}").read()
+                        break
+                    except urllib.error.HTTPError:
+                        continue
+                if content is not None:
+                    fluent_bit_matches = re.findall('FROM (fluent/fluent-bit:.*?)\\\\n', str(content))
+                    if fluent_bit_matches:
+                        matches.extend(fluent_bit_matches)
             
 
     # use set to remove duplicates

--- a/scripts/list-images.py
+++ b/scripts/list-images.py
@@ -4,17 +4,15 @@ import subprocess
 import sys
 import argparse
 import re
-import urllib.error
-import urllib.request
 
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--values", help="path to values.yaml", required=True)
-    parser.add_argument("--fetch-base", help="should it fetch base images (e.g. Fluent Bit for Tailing Sidecar)", action=argparse.BooleanOptionalAction)
+    parser.add_argument("--fetch-base", help="deprecated, kept for backwards compatibility", action=argparse.BooleanOptionalAction)
     parser.add_argument("--version", help="helm chart version", default="")
     return parser.parse_args()
 
-def get_sumo_images(version, values, fetch_base):
+def get_sumo_images(version, values):
     subprocess.check_output(f'helm repo add sumologic https://sumologic.github.io/sumologic-kubernetes-collection'.split(' '))
     subprocess.check_output(f'helm repo update'.split(' '))
     command = f'helm template collection sumologic/sumologic --namespace=sumologic --debug --version={version} --values={values}'
@@ -23,35 +21,13 @@ def get_sumo_images(version, values, fetch_base):
     matches = re.findall(r'(?:\s*image:\s*|-image=|prometheus-config-reloader=)(.*?)\\n', str(output))
     if matches == None:
         sys.exit(-1)
-    
-    for match in matches:
-        if fetch_base:
-            # Detect Fluent Bit image used by Tailing Sidecar (older versions)
-            if re.match('.*tailing-sidecar:.*', match):
-                version_tag = match.split(':')[-1]
-                candidate_paths = [
-                    f"sidecar/fluentbit/Dockerfile",
-                    f"sidecar/Dockerfile",
-                ]
-                content = None
-                for path in candidate_paths:
-                    try:
-                        content = urllib.request.urlopen(f"https://raw.githubusercontent.com/SumoLogic/tailing-sidecar/v{version_tag}/{path}").read()
-                        break
-                    except urllib.error.HTTPError:
-                        continue
-                if content is not None:
-                    fluent_bit_matches = re.findall('FROM (fluent/fluent-bit:.*?)\\\\n', str(content))
-                    if fluent_bit_matches:
-                        matches.extend(fluent_bit_matches)
-            
 
     # use set to remove duplicates
     return sorted({match.strip('\'"') for match in matches})
 
 if __name__ == '__main__':
     args = parse_args()
-    images = get_sumo_images(args.version, args.values, args.fetch_base)
+    images = get_sumo_images(args.version, args.values)
     
     for i in images:
         print(i)

--- a/telegraf-operator/Dockerfile
+++ b/telegraf-operator/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/telegraf-operator:v${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/telegraf/Dockerfile
+++ b/telegraf/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/telegraf:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/thanos/Dockerfile
+++ b/thanos/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/thanos:v${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.6
+FROM registry.access.redhat.com/ubi9/ubi:9.7
 ARG UPSTREAM_VERSION
 ARG RELEASE
 


### PR DESCRIPTION
Updated UBI images to avoid vulnerability in building the images 

The build-all CI step was failing with HTTP Error 404: Not Found because the script tried two hardcoded Fluent Bit Dockerfile paths in the tailing-sidecar repo, but newer versions of tailing-sidecar have fully replaced Fluent Bit with an otelcol-based sidecar — neither path exists anymore.