### PR TITLE
Updating ubi version and removing breaking test

### DIFF
--- a/.github/workflows/build_and_certify.yml
+++ b/.github/workflows/build_and_certify.yml
@@ -176,29 +176,6 @@ jobs:
             fi
           fi
       
-      - name: Verify SHA Published in Registry
-        id: verify_published
-        if: steps.digest.outputs.status == 'success'
-        run: |
-          FULL_REF="${{ steps.digest.outputs.full_reference }}"
-          echo "Verifying image is published: ${FULL_REF}"
-
-          MAX_RETRIES=5
-          RETRY_DELAY=30
-          for i in $(seq 1 $MAX_RETRIES); do
-            if docker manifest inspect "${FULL_REF}" >/dev/null 2>&1; then
-              echo "✅ SHA is published and reachable in registry"
-              echo "published=true" >> $GITHUB_OUTPUT
-              exit 0
-            fi
-            echo "⏳ Attempt ${i}/${MAX_RETRIES}: SHA not yet visible, retrying in ${RETRY_DELAY}s..."
-            sleep $RETRY_DELAY
-          done
-
-          echo "❌ SHA ${FULL_REF} is not published in registry after ${MAX_RETRIES} attempts"
-          echo "published=false" >> $GITHUB_OUTPUT
-          exit 1
-
       - name: Handle Error Case
         if: steps.check.outputs.ubi_exists == 'false' && steps.check.outputs.has_dockerfile == 'false'
         run: |
@@ -216,11 +193,6 @@ jobs:
             DIGEST=""
             FULL_REF=""
             ERROR_MSG="No UBI image in ECR and no Dockerfile found"
-          elif [ "${{ steps.verify_published.outputs.published }}" == "false" ]; then
-            STATUS="error"
-            DIGEST="${{ steps.digest.outputs.digest }}"
-            FULL_REF="${{ steps.digest.outputs.full_reference }}"
-            ERROR_MSG="SHA certified but not yet published in registry"
           else
             STATUS="${{ steps.digest.outputs.status || 'pending' }}"
             DIGEST="${{ steps.digest.outputs.digest }}"

--- a/autoinstrumentation-dotnet/Dockerfile
+++ b/autoinstrumentation-dotnet/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/autoinstrumentation-dotnet:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/autoinstrumentation-java/Dockerfile
+++ b/autoinstrumentation-java/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/autoinstrumentation-java:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/autoinstrumentation-nodejs/Dockerfile
+++ b/autoinstrumentation-nodejs/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/autoinstrumentation-nodejs:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/autoinstrumentation-python/Dockerfile
+++ b/autoinstrumentation-python/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/autoinstrumentation-python:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/busybox/Dockerfile
+++ b/busybox/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 
 LABEL name="Busybox Base image" \
     vendor="Sumo Logic" \

--- a/fluent-bit/Dockerfile
+++ b/fluent-bit/Dockerfile
@@ -1,6 +1,6 @@
 ARG UPSTREAM_VERSION
 
-FROM registry.access.redhat.com/ubi9/ubi:9.7 as builder
+FROM registry.access.redhat.com/ubi9/ubi:9.8 as builder
 ARG UPSTREAM_VERSION
 
 ARG BISON_VERSION=3.8.2
@@ -61,7 +61,7 @@ RUN install bin/fluent-bit /fluent-bit/bin/
 RUN cp /tmp/src/conf/*.conf /fluent-bit/etc/
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/kube-rbac-proxy/Dockerfile
+++ b/kube-rbac-proxy/Dockerfile
@@ -4,7 +4,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/kube-rbac-proxy:v${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/kube-state-metrics/Dockerfile
+++ b/kube-state-metrics/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/kube-state-metrics:v${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/metrics-server/Dockerfile
+++ b/metrics-server/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM docker.io/bitnamilegacy/metrics-server:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/nginx-unprivileged/Dockerfile
+++ b/nginx-unprivileged/Dockerfile
@@ -6,7 +6,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/nginx-unprivileged:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 ARG NGINX_UID=999

--- a/node-exporter/Dockerfile
+++ b/node-exporter/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/node-exporter:v${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/opentelemetry-collector/Dockerfile
+++ b/opentelemetry-collector/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM otel/opentelemetry-collector-contrib:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/opentelemetry-operator/Dockerfile
+++ b/opentelemetry-operator/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/opentelemetry-operator:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/prometheus-config-reloader/Dockerfile
+++ b/prometheus-config-reloader/Dockerfile
@@ -4,7 +4,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/prometheus-config-reloader:v${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/prometheus-operator/Dockerfile
+++ b/prometheus-operator/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/prometheus-operator:v${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -6,7 +6,7 @@ FROM public.ecr.aws/sumologic/prometheus:v${UPSTREAM_VERSION} as builder
 ## Build RedHat compliant image
 ARG ARCH="amd64"
 ARG OS="linux"
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/scripts/values.yaml
+++ b/scripts/values.yaml
@@ -23,6 +23,6 @@ instrumentation:
   instrumentationNamespaces: "sumologic"
 kube-prometheus-stack:
   prometheusOperator:
-    enabled: true
+    enabled: false
   prometheus:
-    enabled: true
+    enabled: false

--- a/sumo-ubi-minimal/Dockerfile
+++ b/sumo-ubi-minimal/Dockerfile
@@ -1,4 +1,4 @@
-ARG UPSTREAM_VERSION='9.6-1758184547'
+ARG UPSTREAM_VERSION='9.8'
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:${UPSTREAM_VERSION}
 

--- a/telegraf-operator/Dockerfile
+++ b/telegraf-operator/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/telegraf-operator:v${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/telegraf/Dockerfile
+++ b/telegraf/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/telegraf:${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 

--- a/thanos/Dockerfile
+++ b/thanos/Dockerfile
@@ -5,7 +5,7 @@ ARG UPSTREAM_VERSION
 FROM public.ecr.aws/sumologic/thanos:v${UPSTREAM_VERSION} as builder
 
 ## Build RedHat compliant image
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG UPSTREAM_VERSION
 ARG RELEASE
 


### PR DESCRIPTION
I am removing the blocking test, because sometimes redhat can take 2-3 hours to publish the image, means this test will block the flow, Already added 1 CI test in helm operator repo to check if the image is publish or not that is sufficient to catch any image which is not published in the release process.